### PR TITLE
Detecting when all ships sank. Also, PandaRage should work now.

### DIFF
--- a/PandaBattleship.API.Tests/BoardTests.cs
+++ b/PandaBattleship.API.Tests/BoardTests.cs
@@ -80,4 +80,23 @@ public class BoardTests
         Assert.Equal("blocked", grid[1][1]);
         Assert.Equal("empty", grid[9][9]);
     }
+
+    [Fact]
+    public void AreAllShipsSunk_WhenEveryShipIsSunk_ReturnsTrue()
+    {
+        var board = new Board(new ShipLayout
+        {
+            Ships =
+            [
+                new Ship { Type = "Submarine", Coords = [[0, 0]] },
+                new Ship { Type = "Destroyer", Coords = [[2, 2], [2, 3]] }
+            ]
+        });
+
+        board.Attack(0, 0);
+        board.Attack(2, 2);
+        board.Attack(2, 3);
+
+        Assert.True(board.AreAllShipsSunk());
+    }
 }

--- a/PandaBattleship.API.Tests/GameTurnTests.cs
+++ b/PandaBattleship.API.Tests/GameTurnTests.cs
@@ -40,6 +40,25 @@ public class GameTurnTests
         Assert.Equal("player-2", game.CurrentPlayerId);
     }
 
+    [Fact]
+    public void ProcessAttack_WhenPlayerSinksLastOpponentShip_FinishesGameWithWinner()
+    {
+        var game = CreateGameWithCurrentPlayer("player-1");
+
+        game.ProcessAttack("player-1", 1, 1);
+        game.ProcessAttack("player-1", 1, 2);
+
+        var playerView = game.GetPlayerView("player-1");
+        var opponentView = game.GetPlayerView("player-2");
+
+        Assert.Equal("finished", game.GameStatus);
+        Assert.Equal("player-1", game.Winner);
+        Assert.Equal("finished", playerView.GameStatus);
+        Assert.Equal("player-1", playerView.Winner);
+        Assert.Equal("finished", opponentView.GameStatus);
+        Assert.Equal("player-1", opponentView.Winner);
+    }
+
     private static Game CreateGameWithCurrentPlayer(string currentPlayerId)
     {
         var game = new Game("game-1", new Dictionary<string, Board>

--- a/PandaBattleship.API/Model/Board.cs
+++ b/PandaBattleship.API/Model/Board.cs
@@ -118,6 +118,12 @@ public class Board
         return ship.Coords.Any(coord => coord[0] == x && coord[1] == y);
     }
 
+    public bool AreAllShipsSunk()
+    {
+        return _layout.Ships.All(ship =>
+            ship.Coords.All(coord => _grid[coord[0], coord[1]] == "sunk"));
+    }
+
     public string[][] GetGrid()
     {
         var result = new string[GridSize][];

--- a/PandaBattleship.API/Model/Game.cs
+++ b/PandaBattleship.API/Model/Game.cs
@@ -4,6 +4,8 @@ public class Game
 {
     public string GameId { get; }
     public string CurrentPlayerId { get; private set; }
+    public string GameStatus { get; private set; } = "inProgress";
+    public string? Winner { get; private set; }
     public Dictionary<string, Board> PlayerBoards { get; }
 
     public Game(string gameId, Dictionary<string, Board> boards)
@@ -18,11 +20,21 @@ public class Game
 
     public AttackResult ProcessAttack(string playerId, int x, int y)
     {
+        if (GameStatus == "finished")
+            throw new Exception("Game is already finished");
+
         if (playerId != CurrentPlayerId)
             throw new Exception("Not your turn");
 
         var opponentId = PlayerBoards.Keys.First(id => id != playerId);
         var result = PlayerBoards[opponentId].Attack(x, y);
+
+        if (PlayerBoards[opponentId].AreAllShipsSunk())
+        {
+            GameStatus = "finished";
+            Winner = playerId;
+            return result;
+        }
 
         if (!result.IsHit)
         {
@@ -38,8 +50,10 @@ public class Game
         return new GameStateDto
         {
             CurrentTurn = CurrentPlayerId,
+            GameStatus = GameStatus,
             PlayerBoard = PlayerBoards[playerId].GetGrid(),
-            EnemyBoard = PlayerBoards[opponentId].GetMaskedGrid()
+            EnemyBoard = PlayerBoards[opponentId].GetMaskedGrid(),
+            Winner = Winner
         };
     }
 }

--- a/PandaBattleship.API/Model/GameStateDto.cs
+++ b/PandaBattleship.API/Model/GameStateDto.cs
@@ -6,6 +6,7 @@ public class GameStateDto
     public string GameStatus { get; set; } = "inProgress";
     public string[][] PlayerBoard { get; set; } = Array.Empty<string[]>();
     public string[][] EnemyBoard { get; set; } = Array.Empty<string[]>();
+    public string? Winner { get; set; }
 
     public static GameStateDto Waiting()
     {

--- a/PandaBattleship.FE/src/components/GamePage.tsx
+++ b/PandaBattleship.FE/src/components/GamePage.tsx
@@ -1,6 +1,7 @@
 import Confetti from "react-confetti";
 import { useGameHub } from "../hooks/useGameHub";
 import { Board } from "./Board";
+import PandaRage from "./PandaRage";
 import getOrCreatePlayerId from "../utils/playerId";
 import pandaLogo from "../assets/brave_panda_1024.png";
 
@@ -31,10 +32,12 @@ export const GameBoard: React.FC = () => {
     const isWaitingForOpponent = gameState.gameStatus === "waiting";
     const isFinished = gameState.gameStatus === "finished";
     const didPlayerWin = isFinished && gameState.winner === playerId;
+    const didPlayerLose = isFinished && !didPlayerWin;
 
     return (
         <>
             {didPlayerWin && <Confetti />}
+            {didPlayerLose && <PandaRage />}
             <div className="max-w-5xl mx-auto p-1 text-center min-h-screen flex flex-col items-center">
                 <PageHeader />
 

--- a/PandaBattleship.FE/src/components/PandaRage.jsx
+++ b/PandaBattleship.FE/src/components/PandaRage.jsx
@@ -4,7 +4,7 @@ export default function PandaRage({ onComplete }) {
 
     return (
         <div className="rage-overlay">
-            <div className="rage-flash" />
+            <div className="rage-flash" onAnimationEnd={onComplete} />
             <div className="rage-message text-slate-700 text-xl font-bold font-poppins bg-amber-100
                 px-2 py-1 gap-2 rounded-full transition-colors drop-shadow-l tracking-wide animate-pulse">
                 MISSION FAILED


### PR DESCRIPTION
# Summary

This Pull Request introduces enhancements to the PandaBattleship game, implementing new functionality to detect game-ending conditions and provide better feedback to players. Alongside backend updates, it includes changes to the frontend to visualize the game status and display animations for win/loss outcomes.

## Main Changes:
### Backend Improvements:

- Introduced functionality to check if all ships are sunk (AreAllShipsSunk) in the Board model.
- Added new properties GameStatus and Winner in the Game model to handle game completion logic.
- Updated ProcessAttack in the Game model to detect and handle game-ending scenarios.
- Extended the GameStateDto to include the Winner field for front-end synchronization.

### Unit Tests:

- Added test cases in BoardTests to verify AreAllShipsSunk logic.
- Added test cases in GameTurnTests to ensure correct handling when a player sinks the last opponent ship.

### Frontend Enhancements:

- Updated GamePage.tsx to conditionally render animations for win (Confetti) and loss (PandaRage) states.
- Introduced a new PandaRage component for visualizing loss animations.
- Enhanced PandaRage component with animation completion handling.