### PR TITLE
Update GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -30,14 +30,14 @@ jobs:
       image-tag: ${{ steps.vars.outputs.image-tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set image tag
         id: vars
         run: echo "image-tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_DEV }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_DEV }}
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_DEV }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_DEV }}

--- a/.github/workflows/reusable-build-api.yml
+++ b/.github/workflows/reusable-build-api.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
Bumps the workflow actions off the deprecated Node 20 runtime (all target versions run on node24):

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-dotnet` | v4 | v5 |
| `azure/login` | v2 | v3 |

Clears the "Node.js 20 is deprecated" warnings in Actions runs.