### PR TITLE
Run tests with coverage summary in build-api CI

### DIFF
--- a/.github/scripts/test-summary.py
+++ b/.github/scripts/test-summary.py
@@ -46,9 +46,9 @@ lines = [
     "",
     "| Result | Count |",
     "| :-- | --: |",
-    f"| ✅ Passed | {passed} |",
-    f"| ❌ Failed | {failed} |",
-    f"| ⏭️ Skipped | {skipped} |",
+    f"| Passed | {passed} |",
+    f"| Failed | {failed} |",
+    f"| Skipped | {skipped} |",
     f"| **Total** | **{total}** |",
 ]
 print("\n".join(lines))

--- a/.github/scripts/test-summary.py
+++ b/.github/scripts/test-summary.py
@@ -1,0 +1,54 @@
+"""Summarise .trx test results as GitHub-flavoured markdown.
+
+Reads every *.trx file under the results directory passed as the first
+argument (default: "TestResults"), sums the counters across all test
+projects, and prints a markdown block suitable for $GITHUB_STEP_SUMMARY.
+
+A green check is shown only when no tests failed or errored.
+"""
+
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+# Emit UTF-8 regardless of the host console's default encoding (e.g. Windows cp1252).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+results_dir = sys.argv[1] if len(sys.argv) > 1 else "TestResults"
+ns = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+
+total = passed = failed = 0
+found = False
+for path in glob.glob(os.path.join(results_dir, "**", "*.trx"), recursive=True):
+    counters = ET.parse(path).getroot().find(".//t:ResultSummary/t:Counters", ns)
+    if counters is None:
+        continue
+    found = True
+    total += int(counters.get("total", 0))
+    passed += int(counters.get("passed", 0))
+    failed += int(counters.get("failed", 0)) + int(counters.get("error", 0))
+
+skipped = max(total - passed - failed, 0)
+ok = found and failed == 0
+icon = "✅" if ok else "❌"
+
+if not found:
+    headline = "No test results found"
+elif ok:
+    headline = f"All {total} tests passed"
+else:
+    headline = f"{failed} of {total} tests failed"
+
+lines = [
+    f"## {icon} Tests — {headline}",
+    "",
+    "| Result | Count |",
+    "| :-- | --: |",
+    f"| ✅ Passed | {passed} |",
+    f"| ❌ Failed | {failed} |",
+    f"| ⏭️ Skipped | {skipped} |",
+    f"| **Total** | **{total}** |",
+]
+print("\n".join(lines))

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -7,10 +7,60 @@ on:
     paths:
       - 'PandaBattleship.API/**'
       - 'PandaBattleship.ServiceDefaults/**'
+      - 'PandaBattleship.API.Tests/**'
+      - 'PandaBattleship.API.IntegrationTests/**'
+      - 'PandaBattleship.Tests.slnf'
       - '.github/workflows/build-api.yml'
-      - '.github/workflows/reusable-build-api.yml'
+      - '.github/scripts/test-summary.py'
 
 jobs:
-  build:
-    name: API
-    uses: ./.github/workflows/reusable-build-api.yml
+  build-and-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      # Uses a solution filter (not the full .sln) so only the test projects
+      # and their .NET dependencies build - the Vite frontend (npm) and Aspire
+      # AppHost are intentionally excluded from CI.
+      - name: Restore
+        run: dotnet restore PandaBattleship.Tests.slnf
+
+      - name: Build
+        run: dotnet build PandaBattleship.Tests.slnf --no-restore --configuration Release
+
+      - name: Test
+        run: >
+          dotnet test PandaBattleship.Tests.slnf
+          --no-build
+          --configuration Release
+          --logger "trx"
+          --collect:"XPlat Code Coverage"
+          --results-directory ${{ github.workspace }}/TestResults
+
+      - name: Generate coverage report
+        if: ${{ !cancelled() }}
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          reportgenerator \
+            -reports:"${{ github.workspace }}/TestResults/**/coverage.cobertura.xml" \
+            -targetdir:"${{ github.workspace }}/CoverageReport" \
+            -reporttypes:MarkdownSummaryGithub
+
+      - name: Publish summary
+        if: ${{ !cancelled() }}
+        run: |
+          python3 .github/scripts/test-summary.py "${{ github.workspace }}/TestResults" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "${{ github.workspace }}/CoverageReport/SummaryGithub.md" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat "${{ github.workspace }}/CoverageReport/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -7,9 +7,9 @@ on:
     paths:
       - 'PandaBattleship.API/**'
       - 'PandaBattleship.ServiceDefaults/**'
+      - 'PandaBattleship.AppHost/**'
       - 'PandaBattleship.API.Tests/**'
       - 'PandaBattleship.API.IntegrationTests/**'
-      - 'PandaBattleship.Tests.slnf'
       - '.github/workflows/build-api.yml'
       - '.github/scripts/test-summary.py'
 
@@ -28,18 +28,18 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Uses a solution filter (not the full .sln) so only the test projects
-      # and their .NET dependencies build - the Vite frontend (npm) and Aspire
-      # AppHost are intentionally excluded from CI.
+      # Builds/tests the whole solution. The Vite frontend esproj has no build
+      # configuration in the .sln, so dotnet never builds it (no npm/Vite in CI);
+      # any .NET test project added to the solution is picked up automatically.
       - name: Restore
-        run: dotnet restore PandaBattleship.Tests.slnf
+        run: dotnet restore PandaBattleship.sln
 
       - name: Build
-        run: dotnet build PandaBattleship.Tests.slnf --no-restore --configuration Release
+        run: dotnet build PandaBattleship.sln --no-restore --configuration Release
 
       - name: Test
         run: >
-          dotnet test PandaBattleship.Tests.slnf
+          dotnet test PandaBattleship.sln
           --no-build
           --configuration Release
           --logger "trx"

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -10,6 +10,7 @@ on:
       - 'PandaBattleship.AppHost/**'
       - 'PandaBattleship.API.Tests/**'
       - 'PandaBattleship.API.IntegrationTests/**'
+      - 'coverlet.runsettings'
       - '.github/workflows/build-api.yml'
       - '.github/scripts/test-summary.py'
 
@@ -44,6 +45,7 @@ jobs:
           --configuration Release
           --logger "trx"
           --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
           --results-directory ${{ github.workspace }}/TestResults
 
       - name: Generate coverage report
@@ -62,5 +64,6 @@ jobs:
           python3 .github/scripts/test-summary.py "${{ github.workspace }}/TestResults" >> "$GITHUB_STEP_SUMMARY"
           if [ -f "${{ github.workspace }}/CoverageReport/SummaryGithub.md" ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            cat "${{ github.workspace }}/CoverageReport/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+            # Drop the "Method coverage" row (a ReportGenerator sponsors-only placeholder).
+            grep -v 'Method coverage' "${{ github.workspace }}/CoverageReport/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-test:
-    name: Build & test
+    name: Build & Test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/PandaBattleship.Tests.slnf
+++ b/PandaBattleship.Tests.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "PandaBattleship.sln",
+    "projects": [
+      "PandaBattleship.API.IntegrationTests\\PandaBattleship.API.IntegrationTests.csproj",
+      "PandaBattleship.API.Tests\\PandaBattleship.API.Tests.csproj"
+    ]
+  }
+}

--- a/PandaBattleship.Tests.slnf
+++ b/PandaBattleship.Tests.slnf
@@ -1,9 +1,0 @@
-{
-  "solution": {
-    "path": "PandaBattleship.sln",
-    "projects": [
-      "PandaBattleship.API.IntegrationTests\\PandaBattleship.API.IntegrationTests.csproj",
-      "PandaBattleship.API.Tests\\PandaBattleship.API.Tests.csproj"
-    ]
-  }
-}

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <!-- Keep coverage to hand-written first-party code: drop source-generated
+               files, which live under obj/. (Not CompilerGeneratedAttribute - that
+               would also exclude legitimate record types.) -->
+          <ExcludeByFile>**/obj/**/*.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## What

Adds automated test execution + a results/coverage summary to the `build-api` PR workflow.

## How

- **Tests run on the root solution** via `dotnet test PandaBattleship.sln`. This auto-discovers every .NET test project (no per-project list to maintain) and builds the Aspire AppHost (a future test will need it). The Vite frontend esproj has **no build configuration in the `.sln`**, so `dotnet` never builds it — no npm/Vite runs in CI.
- **Coverage** is collected with `coverlet.collector` (already referenced by both test projects) via `--collect:"XPlat Code Coverage"`, then rendered to markdown with ReportGenerator (`MarkdownSummaryGithub`).
- **Step summary** (`.github/scripts/test-summary.py`) writes a headline that shows **✅ when all tests pass** and **❌ + the failing count** when any fail, followed by a plain results table (Passed / Failed / Skipped / Total) and the coverage table — Vitest-style, on the run's summary page.
- The previous build-only PR job (which delegated to `reusable-build-api.yml`) is replaced by this self-contained `Build & Test` job. `reusable-build-api.yml` is unchanged and still used by `deploy-api.yml`.

## Verified

- On the GitHub runner: `Build & Test` passes (~39s); FE/npm/Vite never build.
- Locally, both summary states render correctly:
  - all green -> `## ✅ Tests — All 17 tests passed`
  - one failing test -> `## ❌ Tests — 1 of 18 tests failed`
- Coverage report renders (line 57.3%, branch 41.2%).