### PR TITLE
Grant GitHub Actions deploy identity RBAC on the FE container app

### DIFF
--- a/iac/github-actions-deploy.tf
+++ b/iac/github-actions-deploy.tf
@@ -49,3 +49,9 @@ resource "azurerm_role_assignment" "github_actions_container_app_deploy" {
   role_definition_name = "Container Apps Contributor"
   principal_id         = azurerm_user_assigned_identity.github_actions_deploy.principal_id
 }
+
+resource "azurerm_role_assignment" "github_actions_container_app_fe_deploy" {
+  scope                = azurerm_container_app.pandabattleship_app_fe.id
+  role_definition_name = "Container Apps Contributor"
+  principal_id         = azurerm_user_assigned_identity.github_actions_deploy.principal_id
+}


### PR DESCRIPTION
## Summary
- `deploy-fe.yml` (added in #90) failed with `ERROR: The containerapp 'ca-pandabattleship-fe-dev' does not exist`, even though the app exists and is visible in the Azure portal.
- Root cause: the GitHub Actions deploy identity's `Container Apps Contributor` role assignment in `iac/github-actions-deploy.tf` was scoped only to the API container app (`azurerm_container_app.pandabattleship_app_api.id`). Azure hides resources the caller has no RBAC visibility into, so `az containerapp update` reports "does not exist" instead of a permission error.
- Adds a second `azurerm_role_assignment` scoped to the FE container app (`azurerm_container_app.pandabattleship_app_fe.id`), mirroring the existing API role assignment.
