### PR TITLE
Make game boards responsive: side-by-side on desktop, stacked on mobile

### DIFF
--- a/PandaBattleship.FE/src/components/GameOriginal.tsx
+++ b/PandaBattleship.FE/src/components/GameOriginal.tsx
@@ -163,37 +163,42 @@ const GameOriginal = () => {
                 <Confetti />
             )}
             <div className="flex flex-col items-center gap-1">
-                <div className="flex flex-row items-center gap-4 pb-1">
-                    { !isGameOver && <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full transition-colors tracking-wide flex items-center 
-                        ${isPlayerTurn 
-                            ? ' bg-blue-200 text-cyan-700 ' 
-                                : 'bg-rose-100 text-rose-700 font-semibold tracking-wide animate-pulse'}`}>
-                            {isPlayerTurn ? "Aiming..." : "Enemy Attacking..."}
+                {/* Stacked on small screens, side by side from lg (1024px) up */}
+                <div className="flex flex-col lg:flex-row lg:items-start gap-1 lg:gap-10">
+                    <div className="flex flex-col items-center gap-1">
+                        <div className="flex flex-row items-center gap-4 pb-1">
+                            { !isGameOver && <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full transition-colors tracking-wide flex items-center
+                                ${isPlayerTurn
+                                    ? ' bg-blue-200 text-cyan-700 '
+                                        : 'bg-rose-100 text-rose-700 font-semibold tracking-wide animate-pulse'}`}>
+                                    {isPlayerTurn ? "Aiming..." : "Enemy Attacking..."}
+                                </div>
+                            }
+
+                            { // add a new game button
+                                isGameOver &&
+                                <button
+                                    onClick={startNewGame}
+                                    className="text-l gap-2 py-1 px-1 rounded-full bg-amber-300 hover:bg-amber-100
+                                    shadow-sm font-poppins font-semibold text-cyan-700 hover:text-cyan-600 transition-colors">
+                                    New Game
+                                </button>
+                            }
+                            <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">🎯 Enemy Waters</h2>
                         </div>
-                    }
 
-                    { // add a new game button
-                        isGameOver &&
-                        <button
-                            onClick={startNewGame}
-                            className="text-l gap-2 py-1 px-1 rounded-full bg-amber-300 hover:bg-amber-100
-                            shadow-sm font-poppins font-semibold text-cyan-700 hover:text-cyan-600 transition-colors">
-                            New Game
-                        </button>
-                    }
-                    <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">🎯 Enemy Waters</h2>
-                </div>
+                        <div className="flex flex-col items-center">
+                            <GridOriginal grid={enemyGrid} onCellClick={handleEnemyCellClick} waiting={!isPlayerTurn || isGameOver} />
+                            {isGameOver && !didPlayerWin && (
+                                <PandaRage />
+                            )}
+                        </div>
+                    </div>
 
-                <div className="flex flex-col items-center">
-                    <GridOriginal grid={enemyGrid} onCellClick={handleEnemyCellClick} waiting={!isPlayerTurn || isGameOver} />
-                    {isGameOver && !didPlayerWin && (
-                        <PandaRage />
-                    )}
-                </div>
-
-                <div className="flex flex-col gap-1 items-center">
-                    <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">🚢 Your Fleet</h2>
-                    <GridOriginal grid={playerGrid} onCellClick={null} isPlayerGrid={true} disabled={true} />
+                    <div className="flex flex-col gap-1 items-center">
+                        <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">🚢 Your Fleet</h2>
+                        <GridOriginal grid={playerGrid} onCellClick={null} isPlayerGrid={true} disabled={true} />
+                    </div>
                 </div>
 
                 <div className="text-xs text-gray-500 max-h-24 overflow-y-auto">

--- a/PandaBattleship.FE/src/components/GamePage.tsx
+++ b/PandaBattleship.FE/src/components/GamePage.tsx
@@ -52,58 +52,63 @@ export const GameBoard: React.FC = () => {
 
                 <div className="select-none">
                     <div className="flex flex-col items-center gap-1">
-                        <div className="flex flex-row items-center gap-4 pb-1">
-                            {!isFinished && (
-                                <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full transition-colors tracking-wide flex items-center ${
-                                    yourTurn && !isWaitingForOpponent
-                                        ? "bg-blue-200 text-cyan-700"
-                                        : "bg-rose-100 text-rose-700 font-semibold tracking-wide animate-pulse"
-                                }`}>
-                                    {isWaitingForOpponent
-                                        ? "Waiting for opponent..."
-                                        : yourTurn
-                                            ? "Aiming..."
-                                            : "Opponent Attacking..."}
+                        {/* Stacked on small screens, side by side from lg (1024px) up */}
+                        <div className="flex flex-col lg:flex-row lg:items-start gap-1 lg:gap-10">
+                            <div className="flex flex-col items-center gap-1">
+                                <div className="flex flex-row items-center gap-4 pb-1">
+                                    {!isFinished && (
+                                        <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full transition-colors tracking-wide flex items-center ${
+                                            yourTurn && !isWaitingForOpponent
+                                                ? "bg-blue-200 text-cyan-700"
+                                                : "bg-rose-100 text-rose-700 font-semibold tracking-wide animate-pulse"
+                                        }`}>
+                                            {isWaitingForOpponent
+                                                ? "Waiting for opponent..."
+                                                : yourTurn
+                                                    ? "Aiming..."
+                                                    : "Opponent Attacking..."}
+                                        </div>
+                                    )}
+
+                                    {isFinished && (
+                                        <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full tracking-wide ${
+                                            didPlayerWin
+                                                ? "bg-blue-200 text-cyan-700"
+                                                : "bg-rose-100 text-rose-700"
+                                        }`}>
+                                            {didPlayerWin ? "You won!" : "Opponent won!"}
+                                        </div>
+                                    )}
+
+                                    <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">
+                                        🎯 Enemy Waters
+                                    </h2>
                                 </div>
-                            )}
 
-                            {isFinished && (
-                                <div className={`text-l font-semibold px-2 py-1 gap-2 rounded-full tracking-wide ${
-                                    didPlayerWin
-                                        ? "bg-blue-200 text-cyan-700"
-                                        : "bg-rose-100 text-rose-700"
-                                }`}>
-                                    {didPlayerWin ? "You won!" : "Opponent won!"}
+                                <div className="flex flex-col items-center">
+                                    <Board
+                                        grid={gameState.enemyBoard}
+                                        waiting={!yourTurn || isWaitingForOpponent}
+                                        disabled={isFinished || isWaitingForOpponent}
+                                        onClick={(x, y) => {
+                                            if (yourTurn && !isFinished && !isWaitingForOpponent) {
+                                                attack(x, y);
+                                            }
+                                        }}
+                                    />
                                 </div>
-                            )}
+                            </div>
 
-                            <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">
-                                🎯 Enemy Waters
-                            </h2>
-                        </div>
-
-                        <div className="flex flex-col items-center">
-                            <Board
-                                grid={gameState.enemyBoard}
-                                waiting={!yourTurn || isWaitingForOpponent}
-                                disabled={isFinished || isWaitingForOpponent}
-                                onClick={(x, y) => {
-                                    if (yourTurn && !isFinished && !isWaitingForOpponent) {
-                                        attack(x, y);
-                                    }
-                                }}
-                            />
-                        </div>
-
-                        <div className="flex flex-col gap-1 items-center">
-                            <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">
-                                🚢 Your Fleet
-                            </h2>
-                            <Board
-                                grid={gameState.playerBoard}
-                                isPlayerGrid={true}
-                                disabled={true}
-                            />
+                            <div className="flex flex-col gap-1 items-center">
+                                <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">
+                                    🚢 Your Fleet
+                                </h2>
+                                <Board
+                                    grid={gameState.playerBoard}
+                                    isPlayerGrid={true}
+                                    disabled={true}
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Both AI and PvP game modes now use a responsive layout that adapts to screen width:
- **Mobile (< 1024px)**: Boards stack vertically for easy one-handed play
- **Desktop (≥ 1024px)**: Enemy board and your fleet sit side by side for full-screen use

Uses Tailwind's `lg:` breakpoint (1024px) to trigger the layout switch via `flex flex-col lg:flex-row lg:items-start`.

## Changes

- [GameOriginal.tsx](PandaBattleship.FE/src/components/GameOriginal.tsx): Wrapped enemy board + header and fleet grid each in their own flex column, grouped in a flex row container
- [GamePage.tsx](PandaBattleship.FE/src/components/GamePage.tsx): Applied identical responsive layout to PvP game boards

Status messages ("Aiming...", "Waiting for opponent...", etc.) and headers travel with their respective boards.

## Test Plan

- [x] AI mode: Resize browser across 1024px, boards should snap from stacked to side-by-side
- [x] PvP mode: Same responsive behavior across game states (waiting, playing, finished)
- [x] Mobile emulation: Both modes still stack cleanly at 375px width
- [x] `npm run build` passes without errors