### PR TITLE
Add fleet builder to the AI game: drag, rotate, and switch ship shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,11 @@ PandaBattleship is a learning project for building a Battleship game while explo
 
 - `PandaBattleship.FE/src/components/GameOriginal.tsx`
   - Original local/single-player style game component.
+  - "Build Fleet" button opens `FleetBuilder`; `startNewGame` accepts an optional custom player layout.
+
+- `PandaBattleship.FE/src/components/FleetBuilder.tsx`
+  - Fleet builder for the AI game: drag ships with pointer events, rotate, and cycle shapes.
+  - Pure logic (shape catalogue, rotation, no-touching validation) lives in `PandaBattleship.FE/src/utils/fleetBuilder.ts`.
 
 - `PandaBattleship.FE/src/constants/shipLayouts.ts`
   - Frontend copy of ship layouts for local/AI behavior.
@@ -198,6 +203,9 @@ terraform apply
 - `PandaBattleship.FE/tests/shipLayouts.test.ts`
   - Vitest tests for ship layouts, AI shot behavior, and rendered hit cells.
 
+- `PandaBattleship.FE/tests/fleetBuilder.test.ts`
+  - Vitest tests for fleet builder shapes, rotation, and placement validation.
+
 Before finishing changes, run the smallest meaningful verification:
 
 - API/domain changes: `dotnet test`
@@ -209,6 +217,7 @@ Before finishing changes, run the smallest meaningful verification:
 - Add or change API endpoints: `PandaBattleship.API/Program.cs`.
 - Change PvP realtime behavior: `PandaBattleship.API/Hubs/GameHub.cs`, `PandaBattleship.FE/src/hooks/useGameHub.ts`, and `PandaBattleship.FE/src/components/GamePage.tsx`.
 - Change game rules: `PandaBattleship.API/Domain/`, `PandaBattleship.API/Services/GameService.cs`, and matching tests.
+- Change fleet building (AI game): `PandaBattleship.FE/src/components/FleetBuilder.tsx`, `PandaBattleship.FE/src/utils/fleetBuilder.ts`, and `PandaBattleship.FE/tests/fleetBuilder.test.ts`.
 - Change ship layouts:
   - Backend: `PandaBattleship.API/Constants/ShipLayouts.json`
   - Frontend: `PandaBattleship.FE/src/constants/shipLayouts.ts`

--- a/PandaBattleship.FE/src/components/FleetBuilder.tsx
+++ b/PandaBattleship.FE/src/components/FleetBuilder.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useRef, useState } from 'react';
+import { GRID_SIZE } from '../utils/gameHelpers';
+import {
+    SHIP_SHAPES,
+    absoluteCoords,
+    clampAnchor,
+    createDefaultFleet,
+    findInvalidShipIds,
+    rotateCells,
+    toShipLayout,
+    type BuilderShip,
+} from '../utils/fleetBuilder';
+import type { Coordinate, ShipLayout } from '../types/SinglePlayerGame';
+
+interface FleetBuilderProps {
+    onStart: (layout: ShipLayout) => void;
+    onCancel: () => void;
+}
+
+const FleetBuilder = ({ onStart, onCancel }: FleetBuilderProps) => {
+    const [ships, setShips] = useState<BuilderShip[]>(createDefaultFleet);
+    const [selectedId, setSelectedId] = useState<number | null>(null);
+    const gridRef = useRef<HTMLDivElement>(null);
+    // Which ship is being dragged and which cell of it the pointer grabbed,
+    // so the ship moves relative to the grab point instead of jumping.
+    const dragRef = useRef<{ shipId: number; grabOffset: Coordinate } | null>(null);
+
+    const invalidIds = useMemo(() => findInvalidShipIds(ships), [ships]);
+    const selectedShip = ships.find(s => s.id === selectedId) ?? null;
+
+    // Map "row,col" -> ship id for rendering and hit-testing.
+    const cellOwner = useMemo(() => {
+        const owner = new Map<string, number>();
+        ships.forEach(ship =>
+            absoluteCoords(ship).forEach(([r, c]) => owner.set(`${r},${c}`, ship.id))
+        );
+        return owner;
+    }, [ships]);
+
+    const cellFromPointer = (e: React.PointerEvent): Coordinate | null => {
+        const rect = gridRef.current?.getBoundingClientRect();
+        if (!rect) return null;
+        const col = Math.floor(((e.clientX - rect.left) / rect.width) * GRID_SIZE);
+        const row = Math.floor(((e.clientY - rect.top) / rect.height) * GRID_SIZE);
+        if (row < 0 || row >= GRID_SIZE || col < 0 || col >= GRID_SIZE) return null;
+        return [row, col];
+    };
+
+    const handlePointerDown = (e: React.PointerEvent) => {
+        const cell = cellFromPointer(e);
+        if (!cell) return;
+        const shipId = cellOwner.get(`${cell[0]},${cell[1]}`);
+        if (shipId === undefined) {
+            setSelectedId(null);
+            return;
+        }
+        const ship = ships.find(s => s.id === shipId)!;
+        setSelectedId(shipId);
+        dragRef.current = {
+            shipId,
+            grabOffset: [cell[0] - ship.anchor[0], cell[1] - ship.anchor[1]],
+        };
+        // Capture so the drag keeps tracking even when the pointer leaves the
+        // grid. Throws for synthetic events (tests), where capture isn't needed.
+        try {
+            gridRef.current?.setPointerCapture(e.pointerId);
+        } catch { /* no active pointer to capture */ }
+    };
+
+    const handlePointerMove = (e: React.PointerEvent) => {
+        const drag = dragRef.current;
+        if (!drag) return;
+        const cell = cellFromPointer(e);
+        if (!cell) return;
+        setShips(prev => prev.map(ship => {
+            if (ship.id !== drag.shipId) return ship;
+            const wanted: Coordinate = [cell[0] - drag.grabOffset[0], cell[1] - drag.grabOffset[1]];
+            const anchor = clampAnchor(ship.cells, wanted);
+            if (anchor[0] === ship.anchor[0] && anchor[1] === ship.anchor[1]) return ship;
+            return { ...ship, anchor };
+        }));
+    };
+
+    const handlePointerUp = () => {
+        dragRef.current = null;
+    };
+
+    const rotateSelected = () => {
+        if (!selectedShip) return;
+        setShips(prev => prev.map(ship => {
+            if (ship.id !== selectedShip.id) return ship;
+            const cells = rotateCells(ship.cells);
+            return { ...ship, cells, anchor: clampAnchor(cells, ship.anchor) };
+        }));
+    };
+
+    const switchShapeOfSelected = () => {
+        if (!selectedShip) return;
+        setShips(prev => prev.map(ship => {
+            if (ship.id !== selectedShip.id) return ship;
+            const shapes = SHIP_SHAPES[ship.type];
+            const shapeIndex = (ship.shapeIndex + 1) % shapes.length;
+            const cells = shapes[shapeIndex];
+            return { ...ship, shapeIndex, cells, anchor: clampAnchor(cells, ship.anchor) };
+        }));
+    };
+
+    const canSwitchShape = selectedShip !== null && SHIP_SHAPES[selectedShip.type].length > 1;
+    const isFleetValid = invalidIds.size === 0;
+
+    const toolbarButton = "text-sm py-1 px-3 rounded-full bg-white shadow-sm font-semibold " +
+        "text-cyan-700 hover:text-cyan-500 transition-colors " +
+        "disabled:text-gray-300 disabled:cursor-not-allowed";
+
+    return (
+        <div className="flex flex-col items-center gap-2">
+            <h2 className="text-l py-1 px-3 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">
+                🛠️ Build Your Fleet
+            </h2>
+            <p className="text-xs text-gray-500 text-center max-w-md">
+                Drag a ship to move it. Select a ship, then rotate it or switch its shape.
+                Ships cannot touch each other — conflicts show in red.
+            </p>
+
+            <div className="flex flex-row gap-2">
+                <button onClick={rotateSelected} disabled={!selectedShip} className={toolbarButton}>
+                    ⟳ Rotate
+                </button>
+                <button onClick={switchShapeOfSelected} disabled={!canSwitchShape} className={toolbarButton}>
+                    ✨ Switch Shape
+                </button>
+                <button
+                    onClick={() => { setShips(createDefaultFleet()); setSelectedId(null); }}
+                    className={toolbarButton}
+                >
+                    ↺ Reset
+                </button>
+            </div>
+
+            {/* touch-none stops the page scrolling while dragging on mobile */}
+            <div
+                ref={gridRef}
+                className="inline-grid grid-cols-10 gap-0 border border-gray-500 touch-none select-none"
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+            >
+                {Array.from({ length: GRID_SIZE }, (_, row) =>
+                    Array.from({ length: GRID_SIZE }, (_, col) => {
+                        const shipId = cellOwner.get(`${row},${col}`);
+                        const isShip = shipId !== undefined;
+                        const isInvalid = isShip && invalidIds.has(shipId);
+                        const isSelected = isShip && shipId === selectedId;
+                        const shipColor = isInvalid
+                            ? (isSelected ? 'bg-rose-500' : 'bg-rose-300')
+                            : (isSelected ? 'bg-cyan-500' : 'bg-gray-400');
+                        return (
+                            <div
+                                key={`${row}-${col}`}
+                                className={`w-8 h-8 sm:w-10 sm:h-10 border border-gray-500 transition-colors ${
+                                    isShip ? `${shipColor} cursor-grab` : ''
+                                }`}
+                            />
+                        );
+                    })
+                )}
+            </div>
+
+            <div className="text-xs text-gray-500 h-4">
+                {selectedShip
+                    ? `Selected: ${selectedShip.type} (${selectedShip.cells.length} ${selectedShip.cells.length === 1 ? 'cell' : 'cells'})`
+                    : 'Tap a ship to select it.'}
+            </div>
+
+            <div className="flex flex-row gap-3">
+                <button
+                    onClick={onCancel}
+                    className="text-l py-1 px-3 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500 hover:text-gray-400 transition-colors"
+                >
+                    Cancel
+                </button>
+                <button
+                    onClick={() => onStart(toShipLayout(ships))}
+                    disabled={!isFleetValid}
+                    className="text-l py-1 px-3 rounded-full bg-amber-300 hover:bg-amber-100 shadow-sm
+                        font-poppins font-semibold text-cyan-700 hover:text-cyan-600 transition-colors
+                        disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed"
+                >
+                    Start Battle
+                </button>
+            </div>
+            {!isFleetValid && (
+                <div className="text-xs text-rose-500 font-semibold">
+                    Ships in red are touching or overlapping — move them apart to start.
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default FleetBuilder;

--- a/PandaBattleship.FE/src/components/GameOriginal.tsx
+++ b/PandaBattleship.FE/src/components/GameOriginal.tsx
@@ -5,6 +5,7 @@ import { processAiShot, AI_SHOT_DELAY } from '../utils/aiPlayer';
 import { THEMES, CLASSIC_THEME } from '../constants/themes';
 import Confetti from 'react-confetti'
 import GridOriginal from './GridOriginal';
+import FleetBuilder from './FleetBuilder';
 import PandaRage from "./PandaRage";
 import type { ShipLayout, ShotResult, SinglePlayerGrid, TargetStack } from "../types/SinglePlayerGame";
 
@@ -23,8 +24,9 @@ const GameOriginal = () => {
     const aiTargetStackRef = useRef<TargetStack>([]);
     const playerDeadShipsRef = useRef(0);
     const [theme, setTheme] = useState(CLASSIC_THEME);
+    const [isBuildingFleet, setIsBuildingFleet] = useState(false);
 
-    function startNewGame() {
+    function startNewGame(customPlayerLayout?: ShipLayout) {
         // Reset refs used during AI turn loop
         aiTargetStackRef.current = [];
         playerDeadShipsRef.current = 0;
@@ -36,9 +38,10 @@ const GameOriginal = () => {
         setEnemyDeadShips(0);
         setDidPlayerWin(false);
 
-        // Initialize Player Grid
+        // Initialize Player Grid: use the custom-built fleet when provided,
+        // otherwise pick a random predefined layout
         const playerLayoutIdx = Math.floor(Math.random() * SHIP_LAYOUTS.length);
-        const playerLayout = SHIP_LAYOUTS[playerLayoutIdx];
+        const playerLayout = customPlayerLayout ?? SHIP_LAYOUTS[playerLayoutIdx];
         console.log('Initializing game with player layout:', playerLayout.name);
         console.log('Player has', playerLayout.ships.length, 'ships');
         setPlayerShipLayout(playerLayout);
@@ -175,7 +178,30 @@ const GameOriginal = () => {
                     >
                         {THEMES.map(t => <option key={t.name} value={t.name}>{t.name}</option>)}
                     </select>
+                    {!isBuildingFleet && (
+                        <button
+                            onClick={() => setIsBuildingFleet(true)}
+                            // Disabled during the AI turn: starting a new game
+                            // mid-loop would let stale AI shots corrupt the fresh grid
+                            disabled={!isPlayerTurn && !isGameOver}
+                            className="text-xs rounded-full bg-white shadow-sm px-2 py-1 text-cyan-700 font-semibold
+                                hover:text-cyan-500 transition-colors cursor-pointer
+                                disabled:text-gray-300 disabled:cursor-not-allowed"
+                        >
+                            🛠️ Build Fleet
+                        </button>
+                    )}
                 </div>
+                {isBuildingFleet ? (
+                <FleetBuilder
+                    onStart={layout => {
+                        setIsBuildingFleet(false);
+                        startNewGame(layout);
+                    }}
+                    onCancel={() => setIsBuildingFleet(false)}
+                />
+                ) : (
+                <>
                 {/* Stacked on small screens, side by side from lg (1024px) up */}
                 <div className="flex flex-col lg:flex-row lg:items-start gap-1 lg:gap-10">
                     <div className="flex flex-col items-center gap-1">
@@ -191,7 +217,7 @@ const GameOriginal = () => {
                             { // add a new game button
                                 isGameOver &&
                                 <button
-                                    onClick={startNewGame}
+                                    onClick={() => startNewGame()}
                                     className="text-l gap-2 py-1 px-1 rounded-full bg-amber-300 hover:bg-amber-100
                                     shadow-sm font-poppins font-semibold text-cyan-700 hover:text-cyan-600 transition-colors">
                                     New Game
@@ -217,6 +243,8 @@ const GameOriginal = () => {
                 <div className="text-xs text-gray-500 max-h-24 overflow-y-auto">
                     AI Shot History: {aiShotHistory.map((s, i) => `${i+1}: ${s.isHit ? theme.icons.hit : theme.icons.miss} (${s.row},${s.col}) `)}
                 </div>
+                </>
+                )}
             </div>
         </>
     );

--- a/PandaBattleship.FE/src/utils/fleetBuilder.ts
+++ b/PandaBattleship.FE/src/utils/fleetBuilder.ts
@@ -1,0 +1,129 @@
+import type { Coordinate, Ship, ShipLayout } from "../types/SinglePlayerGame";
+import { GRID_SIZE, getSurroundingCells } from "./gameHelpers";
+
+// A ship being edited in the fleet builder. `cells` are offsets from the
+// top-left corner of the ship's bounding box; `anchor` places that corner
+// on the 10x10 grid.
+export interface BuilderShip {
+    id: number;
+    type: Ship["type"];
+    shapeIndex: number;
+    cells: Coordinate[];
+    anchor: Coordinate;
+}
+
+// Shape catalogue per ship type. Lithuanian rules allow any shape as long as
+// cells connect horizontally or vertically, so bigger ships get a few
+// classic polyomino variants to cycle through. Offsets are normalized to the
+// bounding-box top-left corner.
+export const SHIP_SHAPES: Record<Ship["type"], Coordinate[][]> = {
+    Battleship: [
+        [[0, 0], [0, 1], [0, 2], [0, 3]], // I
+        [[0, 0], [1, 0], [1, 1], [1, 2]], // L
+        [[0, 0], [0, 1], [0, 2], [1, 1]], // T
+        [[0, 1], [0, 2], [1, 0], [1, 1]], // S
+        [[0, 0], [0, 1], [1, 0], [1, 1]], // square
+    ],
+    Cruiser: [
+        [[0, 0], [0, 1], [0, 2]], // I
+        [[0, 0], [0, 1], [1, 0]], // L
+    ],
+    Destroyer: [
+        [[0, 0], [0, 1]],
+    ],
+    Submarine: [
+        [[0, 0]],
+    ],
+};
+
+// Shift offsets so the smallest row/col is 0 again after a transform.
+const normalizeCells = (cells: Coordinate[]): Coordinate[] => {
+    const minRow = Math.min(...cells.map(([r]) => r));
+    const minCol = Math.min(...cells.map(([, c]) => c));
+    return cells.map(([r, c]) => [r - minRow, c - minCol] as Coordinate);
+};
+
+// Rotate a shape 90 degrees clockwise: (r, c) -> (c, maxRow - r).
+export const rotateCells = (cells: Coordinate[]): Coordinate[] => {
+    const maxRow = Math.max(...cells.map(([r]) => r));
+    return normalizeCells(cells.map(([r, c]) => [c, maxRow - r] as Coordinate));
+};
+
+// Keep the anchor where the whole shape still fits on the grid.
+export const clampAnchor = (cells: Coordinate[], anchor: Coordinate): Coordinate => {
+    const maxRow = Math.max(...cells.map(([r]) => r));
+    const maxCol = Math.max(...cells.map(([, c]) => c));
+    const row = Math.min(Math.max(anchor[0], 0), GRID_SIZE - 1 - maxRow);
+    const col = Math.min(Math.max(anchor[1], 0), GRID_SIZE - 1 - maxCol);
+    return [row, col];
+};
+
+export const absoluteCoords = (ship: BuilderShip): Coordinate[] =>
+    ship.cells.map(([r, c]) => [ship.anchor[0] + r, ship.anchor[1] + c] as Coordinate);
+
+// Starting arrangement: straight ships in alternating rows so everything is
+// valid before the player touches anything.
+export const createDefaultFleet = (): BuilderShip[] => {
+    const anchorsByType: Record<Ship["type"], Coordinate[]> = {
+        Battleship: [[0, 0]],
+        Cruiser: [[2, 0], [2, 4]],
+        Destroyer: [[4, 0], [4, 3], [4, 6]],
+        Submarine: [[6, 0], [6, 2], [6, 4], [6, 6]],
+    };
+
+    let nextId = 1;
+    return (Object.keys(anchorsByType) as Ship["type"][]).flatMap(type =>
+        anchorsByType[type].map(anchor => ({
+            id: nextId++,
+            type,
+            shapeIndex: 0,
+            cells: SHIP_SHAPES[type][0],
+            anchor,
+        }))
+    );
+};
+
+// A ship is invalid when it leaves the grid, overlaps another ship, or
+// touches one (including diagonally). Both ships in a conflict are flagged
+// so the player sees the whole problem highlighted.
+export const findInvalidShipIds = (ships: BuilderShip[]): Set<number> => {
+    const invalid = new Set<number>();
+    const cellOwner = new Map<string, number>();
+
+    ships.forEach(ship => {
+        absoluteCoords(ship).forEach(([r, c]) => {
+            if (r < 0 || r >= GRID_SIZE || c < 0 || c >= GRID_SIZE) {
+                invalid.add(ship.id);
+                return;
+            }
+            const key = `${r},${c}`;
+            const owner = cellOwner.get(key);
+            if (owner !== undefined && owner !== ship.id) {
+                invalid.add(ship.id);
+                invalid.add(owner);
+            }
+            cellOwner.set(key, ship.id);
+        });
+    });
+
+    ships.forEach(ship => {
+        const surrounding = getSurroundingCells(absoluteCoords(ship));
+        surrounding.forEach(key => {
+            const owner = cellOwner.get(key);
+            if (owner !== undefined && owner !== ship.id) {
+                invalid.add(ship.id);
+                invalid.add(owner);
+            }
+        });
+    });
+
+    return invalid;
+};
+
+export const toShipLayout = (ships: BuilderShip[]): ShipLayout => ({
+    name: "Custom Fleet",
+    ships: ships.map(ship => ({
+        type: ship.type,
+        coords: absoluteCoords(ship),
+    })),
+});

--- a/PandaBattleship.FE/tests/fleetBuilder.test.ts
+++ b/PandaBattleship.FE/tests/fleetBuilder.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+    SHIP_SHAPES,
+    absoluteCoords,
+    clampAnchor,
+    createDefaultFleet,
+    findInvalidShipIds,
+    rotateCells,
+    toShipLayout,
+    type BuilderShip,
+} from '../src/utils/fleetBuilder';
+import type { Coordinate, Ship } from '../src/types/SinglePlayerGame';
+
+const expectedSizes: Record<Ship["type"], number> = {
+    Battleship: 4,
+    Cruiser: 3,
+    Destroyer: 2,
+    Submarine: 1,
+};
+
+// Every cell must be reachable from the first cell via horizontal/vertical
+// steps — the Lithuanian rules connectivity requirement.
+const isConnected = (cells: Coordinate[]): boolean => {
+    const key = ([r, c]: Coordinate) => `${r},${c}`;
+    const cellSet = new Set(cells.map(key));
+    const visited = new Set<string>([key(cells[0])]);
+    const queue: Coordinate[] = [cells[0]];
+    while (queue.length > 0) {
+        const [r, c] = queue.shift()!;
+        const neighbors: Coordinate[] = [[r - 1, c], [r + 1, c], [r, c - 1], [r, c + 1]];
+        neighbors.forEach(next => {
+            if (cellSet.has(key(next)) && !visited.has(key(next))) {
+                visited.add(key(next));
+                queue.push(next);
+            }
+        });
+    }
+    return visited.size === cells.length;
+};
+
+const makeShip = (id: number, type: Ship["type"], anchor: Coordinate, cells?: Coordinate[]): BuilderShip => ({
+    id,
+    type,
+    shapeIndex: 0,
+    cells: cells ?? SHIP_SHAPES[type][0],
+    anchor,
+});
+
+describe('SHIP_SHAPES', () => {
+    it('every shape has the correct cell count for its ship type', () => {
+        (Object.keys(SHIP_SHAPES) as Ship["type"][]).forEach(type => {
+            SHIP_SHAPES[type].forEach(shape => {
+                expect(shape.length, `${type} shape should have ${expectedSizes[type]} cells`)
+                    .toBe(expectedSizes[type]);
+            });
+        });
+    });
+
+    it('every shape is connected horizontally/vertically', () => {
+        (Object.keys(SHIP_SHAPES) as Ship["type"][]).forEach(type => {
+            SHIP_SHAPES[type].forEach((shape, i) => {
+                expect(isConnected(shape), `${type} shape ${i} should be connected`).toBe(true);
+            });
+        });
+    });
+});
+
+describe('rotateCells', () => {
+    it('preserves cell count and connectivity', () => {
+        SHIP_SHAPES.Battleship.forEach(shape => {
+            const rotated = rotateCells(shape);
+            expect(rotated.length).toBe(shape.length);
+            expect(isConnected(rotated)).toBe(true);
+        });
+    });
+
+    it('returns the original shape after four rotations', () => {
+        SHIP_SHAPES.Battleship.forEach(shape => {
+            let cells = shape;
+            for (let i = 0; i < 4; i++) {
+                cells = rotateCells(cells);
+            }
+            const sortCells = (list: Coordinate[]) =>
+                [...list].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+            expect(sortCells(cells)).toEqual(sortCells(shape));
+        });
+    });
+
+    it('turns a horizontal destroyer vertical', () => {
+        expect(rotateCells([[0, 0], [0, 1]])).toEqual([[0, 0], [1, 0]]);
+    });
+});
+
+describe('clampAnchor', () => {
+    it('pulls a shape back inside the grid', () => {
+        const straightFour: Coordinate[] = [[0, 0], [0, 1], [0, 2], [0, 3]];
+        expect(clampAnchor(straightFour, [0, 8])).toEqual([0, 6]);
+        expect(clampAnchor(straightFour, [-2, -5])).toEqual([0, 0]);
+        expect(clampAnchor(straightFour, [12, 3])).toEqual([9, 3]);
+    });
+});
+
+describe('createDefaultFleet', () => {
+    it('creates the full Lithuanian fleet', () => {
+        const fleet = createDefaultFleet();
+        expect(fleet).toHaveLength(10);
+        const countByType = fleet.reduce<Record<string, number>>((acc, ship) => {
+            acc[ship.type] = (acc[ship.type] ?? 0) + 1;
+            return acc;
+        }, {});
+        expect(countByType).toEqual({ Battleship: 1, Cruiser: 2, Destroyer: 3, Submarine: 4 });
+    });
+
+    it('starts with a valid arrangement', () => {
+        expect(findInvalidShipIds(createDefaultFleet()).size).toBe(0);
+    });
+});
+
+describe('findInvalidShipIds', () => {
+    it('accepts ships separated by at least one cell', () => {
+        const ships = [
+            makeShip(1, 'Destroyer', [0, 0]),
+            makeShip(2, 'Destroyer', [2, 0]),
+        ];
+        expect(findInvalidShipIds(ships).size).toBe(0);
+    });
+
+    it('flags both ships when they touch side by side', () => {
+        const ships = [
+            makeShip(1, 'Destroyer', [0, 0]),
+            makeShip(2, 'Destroyer', [1, 0]),
+        ];
+        expect(findInvalidShipIds(ships)).toEqual(new Set([1, 2]));
+    });
+
+    it('flags both ships when they touch diagonally', () => {
+        const ships = [
+            makeShip(1, 'Submarine', [0, 0]),
+            makeShip(2, 'Submarine', [1, 1]),
+        ];
+        expect(findInvalidShipIds(ships)).toEqual(new Set([1, 2]));
+    });
+
+    it('flags overlapping ships', () => {
+        const ships = [
+            makeShip(1, 'Destroyer', [0, 0]),
+            makeShip(2, 'Destroyer', [0, 1]),
+        ];
+        expect(findInvalidShipIds(ships)).toEqual(new Set([1, 2]));
+    });
+
+    it('flags a ship hanging off the grid', () => {
+        const ships = [makeShip(1, 'Destroyer', [0, 9])];
+        expect(findInvalidShipIds(ships)).toEqual(new Set([1]));
+    });
+});
+
+describe('toShipLayout', () => {
+    it('converts builder ships to absolute coordinates', () => {
+        const ships = [makeShip(1, 'Cruiser', [3, 4], [[0, 0], [0, 1], [1, 0]])];
+        const layout = toShipLayout(ships);
+        expect(layout.name).toBe('Custom Fleet');
+        expect(layout.ships).toEqual([
+            { type: 'Cruiser', coords: [[3, 4], [3, 5], [4, 4]] },
+        ]);
+    });
+
+    it('absoluteCoords offsets cells by the anchor', () => {
+        const ship = makeShip(1, 'Destroyer', [5, 5]);
+        expect(absoluteCoords(ship)).toEqual([[5, 5], [5, 6]]);
+    });
+});


### PR DESCRIPTION
## What changed

Adds an optional fleet builder to the AI game (`/` and `/ai`). The existing random-layout flow is unchanged; a new "🛠️ Build Fleet" button next to the theme selector opens a builder screen where the player can:

- **Drag** ships across the 10x10 grid (pointer events, so mouse and touch both work; ships clamp to the grid edges)
- **Rotate** the selected ship 90° at a time
- **Switch shapes** — Lithuanian rules allow any connected shape, so the battleship cycles through I/L/T/S/square variants and cruisers through I/L
- Live validation flags touching/overlapping ships in red and disables "Start Battle" until the layout is legal; Cancel returns to the current game untouched

"Start Battle" starts a new game with the custom fleet against a randomly placed enemy.

## Implementation notes

- `src/components/FleetBuilder.tsx` — the interactive UI; drag is pointer-event based with pointer capture (guarded for synthetic events in tests)
- `src/utils/fleetBuilder.ts` — pure, unit-testable logic: shape catalogue, rotation, anchor clamping, no-touching validation, conversion to `ShipLayout`
- `GameOriginal.tsx` — `startNewGame` now takes an optional custom layout. Two small hardening fixes: `onClick={() => startNewGame()}` so the click event can't leak in as a layout argument, and the Build Fleet button is disabled during the AI turn so a new game can't be started while the AI shot loop is still writing to the old grid
- `tests/fleetBuilder.test.ts` — 14 new Vitest tests (shape sizes/connectivity, rotation round-trip, clamping, validation of touching/overlapping/out-of-bounds ships)
- AGENTS.md updated per repo convention

## Verification

- `npm run test` (19 passed), `npm run build`, `npm run lint` all clean
- Drove the full flow in the browser: opened the builder, dragged the battleship, rotated it, switched it to an L-shape, confirmed conflicts highlighted red and blocked starting, moved it clear, started the battle, and confirmed the in-game player grid matched the built layout exactly (all 20 cells) with the AI responding normally and no console errors