### PR TITLE
Add home page with quick-start links to both game modes

### DIFF
--- a/PandaBattleship.FE/src/AppOriginal.tsx
+++ b/PandaBattleship.FE/src/AppOriginal.tsx
@@ -1,14 +1,11 @@
 import GameOriginal from './components/GameOriginal';
 import DisplayAllLayouts from './components/DisplayAllLayouts';
-import pandaLogo from './assets/brave_panda_1024.png'
+import { PageHeader } from './components/PageHeader';
 
 export default function AppOriginal() {
     return (
-        <div className="max-w-5xl mx-auto p-1 text-center min-h-screen flex flex-col items-center">
-            <div className="flex items-center gap-2">
-                <h1 className="font-bold text-3xl">Panda Battleship</h1>
-                <img src={pandaLogo} className="max-w-30" alt="Panda Battleship" />
-            </div>
+        <div className="max-w-5xl mx-auto px-1 pb-1 pt-4 text-center min-h-screen flex flex-col items-center">
+            <PageHeader />
             <div className="select-none">
                 <GameOriginal />
             </div>

--- a/PandaBattleship.FE/src/components/GamePage.tsx
+++ b/PandaBattleship.FE/src/components/GamePage.tsx
@@ -27,7 +27,7 @@ export const GameBoard: React.FC = () => {
 
     if (!gameState) {
         return (
-            <div className="max-w-5xl mx-auto p-1 text-center min-h-screen flex flex-col items-center">
+            <div className="max-w-5xl mx-auto px-1 pb-1 pt-4 text-center min-h-screen flex flex-col items-center">
                 <PageHeader />
                 <InviteBar gameId={gameId} inviteUrl={inviteUrl} copyStatus={copyStatus} onCopy={copyInviteUrl} />
                 <div className="text-l font-semibold px-2 py-1 gap-2 rounded-full bg-blue-200 text-cyan-700 tracking-wide">
@@ -46,7 +46,7 @@ export const GameBoard: React.FC = () => {
     return (
         <>
             {didPlayerWin && <Confetti />}
-            <div className="max-w-5xl mx-auto p-1 text-center min-h-screen flex flex-col items-center">
+            <div className="max-w-5xl mx-auto px-1 pb-1 pt-4 text-center min-h-screen flex flex-col items-center">
                 <PageHeader />
                 <InviteBar gameId={gameId} inviteUrl={inviteUrl} copyStatus={copyStatus} onCopy={copyInviteUrl} />
 

--- a/PandaBattleship.FE/src/components/HomePage.tsx
+++ b/PandaBattleship.FE/src/components/HomePage.tsx
@@ -1,0 +1,58 @@
+import { Link } from "react-router";
+import { PageHeader } from "./PageHeader";
+
+interface GameMode {
+    to: string;
+    title: string;
+    description: string;
+    cta: string;
+}
+
+const gameModes: GameMode[] = [
+    {
+        to: "/ai",
+        title: "Play vs AI",
+        description: "Jump straight into a single-player game against the computer. Build your own fleet or start with a random layout.",
+        cta: "Quick play",
+    },
+    {
+        to: "/pvp",
+        title: "Play vs a Friend",
+        description: "Create a game and share the invite link, or join with a game code.",
+        cta: "Open lobby",
+    },
+];
+
+export const HomePage: React.FC = () => (
+    <div className="max-w-5xl mx-auto p-4 text-center min-h-screen flex flex-col items-center">
+        <PageHeader />
+
+        <main className="w-full max-w-xl flex flex-col gap-4 mt-6">
+            {gameModes.map((mode) => (
+                <Link
+                    key={mode.to}
+                    to={mode.to}
+                    className="block bg-white text-gray-800 rounded-lg shadow-sm border border-gray-200 p-6 text-left hover:border-cyan-700 hover:bg-cyan-50 transition-colors"
+                >
+                    <h2 className="text-2xl font-semibold text-cyan-700">{mode.title}</h2>
+                    <p className="mt-1 text-gray-600">{mode.description}</p>
+                    <span className="inline-block mt-3 rounded-md bg-cyan-700 px-4 py-2 font-semibold text-white">
+                        {mode.cta}
+                    </span>
+                </Link>
+            ))}
+
+            <section className="bg-white text-gray-800 rounded-lg shadow-sm border border-gray-200 p-4 text-left">
+                <h2 className="text-xl font-semibold">How to play</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                    Panda Battleship follows the Lithuanian rules on a 10x10 grid: ships can be any
+                    connected shape, ships cannot touch each other, and a hit lets you shoot again.
+                    The first player to sink all 20 enemy ship cells wins.
+                </p>
+                <Link to="/help" className="inline-block mt-2 text-sm font-semibold text-cyan-700 hover:underline">
+                    Read the full rules
+                </Link>
+            </section>
+        </main>
+    </div>
+);

--- a/PandaBattleship.FE/src/components/PageHeader.tsx
+++ b/PandaBattleship.FE/src/components/PageHeader.tsx
@@ -1,8 +1,24 @@
+import { Link } from "react-router";
 import pandaLogo from "../assets/brave_panda_1024.png";
 
+// const navLinks = [
+//     { to: "/ai", label: "Play vs AI" },
+//     { to: "/pvp", label: "Play vs a Friend" },
+//     { to: "/help", label: "Help" },
+// ];
+
 export const PageHeader = () => (
-    <div className="flex items-center gap-2">
-        <h1 className="font-bold text-3xl">Panda Battleship</h1>
-        <img src={pandaLogo} className="max-w-30" alt="Panda Battleship" />
-    </div>
+    <header className="flex flex-col items-center">
+        <Link to="/" className="flex items-center gap-2 text-inherit hover:text-inherit">
+            <h1 className="font-bold text-3xl">Panda Battleship</h1>
+            <img src={pandaLogo} className="max-w-30" alt="Panda Battleship" />
+        </Link>
+        {/*<nav className="flex gap-4 text-sm font-semibold text-cyan-700">*/}
+        {/*    {navLinks.map((link) => (*/}
+        {/*        <Link key={link.to} to={link.to} className="hover:underline">*/}
+        {/*            {link.label}*/}
+        {/*        </Link>*/}
+        {/*    ))}*/}
+        {/*</nav>*/}
+    </header>
 );

--- a/PandaBattleship.FE/src/index.css
+++ b/PandaBattleship.FE/src/index.css
@@ -9,6 +9,8 @@
   :root {
     @apply font-sans text-white bg-gray-900;
     color-scheme: light dark;
+    /* Reserve scrollbar space so centered content doesn't shift between short and tall pages */
+    scrollbar-gutter: stable;
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;

--- a/PandaBattleship.FE/src/main.tsx
+++ b/PandaBattleship.FE/src/main.tsx
@@ -6,6 +6,7 @@ import AppOriginal from './AppOriginal'
 import { GameBoard } from "./components/GamePage";
 import { PvpLobbyPage } from "./components/PvpLobbyPage";
 import { HelpPage } from "./components/HelpPage";
+import { HomePage } from "./components/HomePage";
 
 const rootElement = document.getElementById('root');
 
@@ -17,7 +18,7 @@ createRoot(rootElement).render(
     <StrictMode>
         <BrowserRouter>
             <Routes>
-                <Route path="/" element={<AppOriginal />}/>
+                <Route path="/" element={<HomePage />}/>
                 <Route path="/ai" element={<AppOriginal />}/>
                 <Route path="/pvp" element={<PvpLobbyPage />}/>
                 <Route path="/pvp/:gameId" element={<GameBoard />}/>


### PR DESCRIPTION
## What changed

- **New `HomePage` at `/`** — the root URL previously auto-started an AI game with no explanation. It now shows a landing page with two large CTA cards (Play vs AI → `/ai`, Play vs a Friend → `/pvp`) and a short "How to play" summary linking to the full rules on `/help`. The whole page fits in one viewport so both CTAs are immediately visible.
- **`PageHeader`** — the logo/title is now a link back to `/` (styled with `text-inherit` so it keeps the original text color). A nav-links row is prepared but commented out for now.
- **`AppOriginal`** — reuses the shared `PageHeader` instead of its own duplicated header markup. The AI game itself now lives only at `/ai`.
- **Header position stability** — the title used to shift when navigating between pages, for two reasons: game pages used `p-1` while other pages used `p-4` (12px vertical jump), and the scrollbar appearing on tall pages nudged centered content left. Fixed by equalizing top padding (`pt-4`) on the game pages and adding `scrollbar-gutter: stable` to `:root`.

## Notes for reviewers

- `DisplayAllLayouts` is intentionally left on the AI game page — it will be handled separately.
- The `HelpPage` still has its own "Game Modes" section; it duplicates the home page but is harmless and can be trimmed once header nav is enabled.
- Verified in the browser: home renders, Quick play starts the AI game, logo returns home, `/help` and `/pvp` render with the shared header, and the title's bounding box is pixel-identical on `/` and `/ai`. `npm run build` (tsc + vite) and all 19 vitest tests pass.