### PR TITLE
Clean up PageHeader: explicit logo width and reusable link-plain utility

### DIFF
--- a/PandaBattleship.FE/src/components/PageHeader.tsx
+++ b/PandaBattleship.FE/src/components/PageHeader.tsx
@@ -9,9 +9,9 @@ import pandaLogo from "../assets/brave_panda_1024.png";
 
 export const PageHeader = () => (
     <header className="flex flex-col items-center">
-        <Link to="/" className="flex items-center gap-2 text-inherit hover:text-inherit">
+        <Link to="/" className="flex items-center gap-2 link-plain">
             <h1 className="font-bold text-3xl">Panda Battleship</h1>
-            <img src={pandaLogo} className="max-w-30" alt="Panda Battleship" />
+            <img src={pandaLogo} className="max-w-[7.5rem]" alt="Panda Battleship" />
         </Link>
         {/*<nav className="flex gap-4 text-sm font-semibold text-cyan-700">*/}
         {/*    {navLinks.map((link) => (*/}

--- a/PandaBattleship.FE/src/index.css
+++ b/PandaBattleship.FE/src/index.css
@@ -23,6 +23,13 @@
     @apply font-medium text-blue-500 no-underline hover:text-blue-400;
   }
 
+  /* Opt a link out of the global blue link color (e.g. brand/card links that
+     carry their own styling). The :hover selector out-specifies `a:hover`. */
+  a.link-plain,
+  a.link-plain:hover {
+    @apply text-inherit;
+  }
+
   body {
     @apply m-0 flex items-center justify-center min-h-screen min-w-80;
   }


### PR DESCRIPTION
## Summary
Small polish pass on `PageHeader` after the home page merge.

- **Explicit logo width** — `max-w-30` → `max-w-[7.5rem]` (same rendered 7.5rem, but reads clearly instead of relying on the v4 spacing-scale math).
- **Reusable `link-plain` utility** — extracted a base-layer rule so links can opt out of the global blue `a` color in one place, replacing the inline `text-inherit hover:text-inherit`. The paired `:hover` selector out-specifies the global `a:hover`, so the color sticks without a `hover:` variant at each call site.

## Verification
`npm run build` (tsc --noEmit + vite build) passes; the compiled CSS emits `a.link-plain, a.link-plain:hover { color: inherit }`.