### PR TITLE
Move all-ship-layouts view to its own page

### DIFF
--- a/PandaBattleship.FE/.gitignore
+++ b/PandaBattleship.FE/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 .vite
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/PandaBattleship.FE/src/AppOriginal.tsx
+++ b/PandaBattleship.FE/src/AppOriginal.tsx
@@ -1,5 +1,4 @@
 import GameOriginal from './components/GameOriginal';
-import DisplayAllLayouts from './components/DisplayAllLayouts';
 import { PageHeader } from './components/PageHeader';
 
 export default function AppOriginal() {
@@ -8,10 +7,6 @@ export default function AppOriginal() {
             <PageHeader />
             <div className="select-none">
                 <GameOriginal />
-            </div>
-
-            <div className="mt-20 w-full border-t border-gray-700 pt-10">
-                <DisplayAllLayouts />
             </div>
         </div>
     )

--- a/PandaBattleship.FE/src/components/AllShipLayoutsPage.tsx
+++ b/PandaBattleship.FE/src/components/AllShipLayoutsPage.tsx
@@ -1,0 +1,12 @@
+import DisplayAllLayouts from "./DisplayAllLayouts";
+import { PageHeader } from "./PageHeader";
+
+export const AllShipLayoutsPage: React.FC = () => (
+    <div className="max-w-5xl mx-auto p-4 text-center min-h-screen flex flex-col items-center">
+        <PageHeader />
+
+        <main className="w-full mt-6">
+            <DisplayAllLayouts />
+        </main>
+    </div>
+);

--- a/PandaBattleship.FE/src/components/DisplayAllLayouts.tsx
+++ b/PandaBattleship.FE/src/components/DisplayAllLayouts.tsx
@@ -31,8 +31,6 @@ const DisplayAllLayouts = () => {
                                             cell === 'ship' ? 'bg-blue-600' : 'bg-gray-800'
                                         }`}
                                     >
-                                        {/* Optional: coordinate debug */}
-                                        {/* <span className="text-[8px] opacity-20">{rowIndex},{colIndex}</span> */}
                                     </div>
                                 ))
                             )}

--- a/PandaBattleship.FE/src/main.tsx
+++ b/PandaBattleship.FE/src/main.tsx
@@ -7,6 +7,7 @@ import { GameBoard } from "./components/GamePage";
 import { PvpLobbyPage } from "./components/PvpLobbyPage";
 import { HelpPage } from "./components/HelpPage";
 import { HomePage } from "./components/HomePage";
+import { AllShipLayoutsPage } from "./components/AllShipLayoutsPage";
 
 const rootElement = document.getElementById('root');
 
@@ -23,6 +24,7 @@ createRoot(rootElement).render(
                 <Route path="/pvp" element={<PvpLobbyPage />}/>
                 <Route path="/pvp/:gameId" element={<GameBoard />}/>
                 <Route path="/help" element={<HelpPage />}/>
+                <Route path="/all-ship-layouts" element={<AllShipLayoutsPage />}/>
             </Routes>
         </BrowserRouter>
     </StrictMode>


### PR DESCRIPTION
## What changed

Moved the "All Ship Layouts" development view off the AI game page (`/ai`) and onto its own dedicated route at `/all-ship-layouts`.

- **New page**: `AllShipLayoutsPage.tsx` wraps the existing `DisplayAllLayouts` component with the shared `PageHeader`, matching the structure of the other standalone pages (e.g. help).
- **Routing**: registered the `/all-ship-layouts` route in `main.tsx`.
- **AI page**: removed the layouts section (and its now-unused import) from `AppOriginal.tsx`, so the AI page only renders the game.
- **Housekeeping**: dropped a leftover debug comment in `DisplayAllLayouts.tsx` and added `*.tsbuildinfo` to the FE `.gitignore`.

## Why

The all-layouts grid is a development/reference view that cluttered the AI game screen. Giving it a dedicated URL keeps the game page focused while preserving the view.

## Notes for reviewers

- The new page isn't linked from any navigation yet (the layouts view was previously an unlinked dev section too). Happy to add a link to the home page or header if wanted.
- Verified in the browser: `/all-ship-layouts` renders all layout grids, and `/ai` no longer shows the layouts section. Type check passes.