### PR TITLE
Organise FE into pages/ and rename legacy *Original components

### DIFF
--- a/PandaBattleship.FE/PandaBattleship.FE.esproj
+++ b/PandaBattleship.FE/PandaBattleship.FE.esproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Script Include="src\components\Board.tsx" />
-    <Script Include="src\components\GamePage.tsx" />
+    <Script Include="src\pages\PvpGamePage.tsx" />
     <Script Include="src\components\PageHeader.tsx" />
-    <Script Include="src\components\PvpLobbyPage.tsx" />
+    <Script Include="src\pages\PvpLobbyPage.tsx" />
     <Script Include="src\hooks\useGameHub.ts" />
     <Script Include="src\types\GameState.ts" />
     <Script Include="src\utils\playerId.ts" />

--- a/PandaBattleship.FE/src/components/SinglePlayerBoard.tsx
+++ b/PandaBattleship.FE/src/components/SinglePlayerBoard.tsx
@@ -1,7 +1,7 @@
 import type { SinglePlayerGrid } from "../types/SinglePlayerGame";
 import { CLASSIC_THEME, type GameTheme } from "../constants/themes";
 
-interface GridOriginalProps {
+interface SinglePlayerBoardProps {
     grid: SinglePlayerGrid;
     onCellClick?: ((row: number, col: number) => void) | null;
     isPlayerGrid?: boolean;
@@ -10,7 +10,7 @@ interface GridOriginalProps {
     theme?: GameTheme;
 }
 
-const GridOriginal = ({ grid, onCellClick, isPlayerGrid = false, disabled = false, waiting = false, theme = CLASSIC_THEME }: GridOriginalProps) => {
+const SinglePlayerBoard = ({ grid, onCellClick, isPlayerGrid = false, disabled = false, waiting = false, theme = CLASSIC_THEME }: SinglePlayerBoardProps) => {
     const cursorType = disabled ? 'cursor-not-allowed'
         : waiting ? 'cursor-wait' : 'cursor-pointer hover:bg-gray-700';
     return (
@@ -37,4 +37,4 @@ const GridOriginal = ({ grid, onCellClick, isPlayerGrid = false, disabled = fals
     );
 };
 
-export default GridOriginal;
+export default SinglePlayerBoard;

--- a/PandaBattleship.FE/src/components/SinglePlayerGame.tsx
+++ b/PandaBattleship.FE/src/components/SinglePlayerGame.tsx
@@ -4,13 +4,13 @@ import { createEmptyGrid, findSunkenShip, markSunkShipOnGrid } from '../utils/ga
 import { processAiShot, AI_SHOT_DELAY } from '../utils/aiPlayer';
 import { THEMES, CLASSIC_THEME } from '../constants/themes';
 import Confetti from 'react-confetti'
-import GridOriginal from './GridOriginal';
+import SinglePlayerBoard from './SinglePlayerBoard';
 import FleetBuilder from './FleetBuilder';
 import PandaRage from "./PandaRage";
 import type { ShipLayout, ShotResult, SinglePlayerGrid, TargetStack } from "../types/SinglePlayerGame";
 
 
-const GameOriginal = () => {
+const SinglePlayerGame = () => {
 
     const [playerGrid, setPlayerGrid] = useState<SinglePlayerGrid>(createEmptyGrid());
     const [enemyGrid, setEnemyGrid] = useState<SinglePlayerGrid>(createEmptyGrid());
@@ -227,7 +227,7 @@ const GameOriginal = () => {
                         </div>
 
                         <div className="flex flex-col items-center">
-                            <GridOriginal grid={enemyGrid} onCellClick={handleEnemyCellClick} waiting={!isPlayerTurn || isGameOver} theme={theme} />
+                            <SinglePlayerBoard grid={enemyGrid} onCellClick={handleEnemyCellClick} waiting={!isPlayerTurn || isGameOver} theme={theme} />
                             {isGameOver && !didPlayerWin && (
                                 <PandaRage />
                             )}
@@ -236,7 +236,7 @@ const GameOriginal = () => {
 
                     <div className="flex flex-col gap-1 items-center">
                         <h2 className="text-l gap-2 py-1 px-1 rounded-full bg-white shadow-sm font-poppins font-semibold text-gray-500">{theme.labels.yourFleet}</h2>
-                        <GridOriginal grid={playerGrid} onCellClick={null} isPlayerGrid={true} disabled={true} theme={theme} />
+                        <SinglePlayerBoard grid={playerGrid} onCellClick={null} isPlayerGrid={true} disabled={true} theme={theme} />
                     </div>
                 </div>
 
@@ -250,4 +250,4 @@ const GameOriginal = () => {
     );
 };
 
-export default GameOriginal;
+export default SinglePlayerGame;

--- a/PandaBattleship.FE/src/main.tsx
+++ b/PandaBattleship.FE/src/main.tsx
@@ -2,12 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Route, Routes } from "react-router";
 import './index.css'
-import AppOriginal from './AppOriginal'
-import { GameBoard } from "./components/GamePage";
-import { PvpLobbyPage } from "./components/PvpLobbyPage";
-import { HelpPage } from "./components/HelpPage";
-import { HomePage } from "./components/HomePage";
-import { AllShipLayoutsPage } from "./components/AllShipLayoutsPage";
+import SinglePlayerPage from './pages/SinglePlayerPage'
+import { PvpGamePage } from "./pages/PvpGamePage";
+import { PvpLobbyPage } from "./pages/PvpLobbyPage";
+import { HelpPage } from "./pages/HelpPage";
+import { HomePage } from "./pages/HomePage";
+import { AllShipLayoutsPage } from "./pages/AllShipLayoutsPage";
 
 const rootElement = document.getElementById('root');
 
@@ -20,9 +20,9 @@ createRoot(rootElement).render(
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<HomePage />}/>
-                <Route path="/ai" element={<AppOriginal />}/>
+                <Route path="/ai" element={<SinglePlayerPage />}/>
                 <Route path="/pvp" element={<PvpLobbyPage />}/>
-                <Route path="/pvp/:gameId" element={<GameBoard />}/>
+                <Route path="/pvp/:gameId" element={<PvpGamePage />}/>
                 <Route path="/help" element={<HelpPage />}/>
                 <Route path="/all-ship-layouts" element={<AllShipLayoutsPage />}/>
             </Routes>

--- a/PandaBattleship.FE/src/pages/AllShipLayoutsPage.tsx
+++ b/PandaBattleship.FE/src/pages/AllShipLayoutsPage.tsx
@@ -1,5 +1,5 @@
-import DisplayAllLayouts from "./DisplayAllLayouts";
-import { PageHeader } from "./PageHeader";
+import DisplayAllLayouts from "../components/DisplayAllLayouts";
+import { PageHeader } from "../components/PageHeader";
 
 export const AllShipLayoutsPage: React.FC = () => (
     <div className="max-w-5xl mx-auto p-4 text-center min-h-screen flex flex-col items-center">

--- a/PandaBattleship.FE/src/pages/HelpPage.tsx
+++ b/PandaBattleship.FE/src/pages/HelpPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { PageHeader } from "./PageHeader";
+import { PageHeader } from "../components/PageHeader";
 
 interface GameLink {
     to: string;

--- a/PandaBattleship.FE/src/pages/HomePage.tsx
+++ b/PandaBattleship.FE/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { PageHeader } from "./PageHeader";
+import { PageHeader } from "../components/PageHeader";
 
 interface GameMode {
     to: string;

--- a/PandaBattleship.FE/src/pages/PvpGamePage.tsx
+++ b/PandaBattleship.FE/src/pages/PvpGamePage.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import Confetti from "react-confetti";
 import { useParams } from "react-router";
 import { useGameHub } from "../hooks/useGameHub";
-import { Board } from "./Board";
-import PandaRage from "./PandaRage";
+import { Board } from "../components/Board";
+import PandaRage from "../components/PandaRage";
 import getOrCreatePlayerId from "../utils/playerId";
-import { PageHeader } from "./PageHeader";
+import { PageHeader } from "../components/PageHeader";
 
-export const GameBoard: React.FC = () => {
+export const PvpGamePage: React.FC = () => {
     const { gameId: routeGameId = "" } = useParams();
     const gameId = routeGameId.toUpperCase();
     const playerId = getOrCreatePlayerId();

--- a/PandaBattleship.FE/src/pages/PvpLobbyPage.tsx
+++ b/PandaBattleship.FE/src/pages/PvpLobbyPage.tsx
@@ -1,6 +1,6 @@
 import { type SubmitEventHandler, useState } from "react";
 import { useNavigate } from "react-router";
-import { PageHeader } from "./PageHeader";
+import { PageHeader } from "../components/PageHeader";
 
 interface CreateGameResponse {
     gameId: string;

--- a/PandaBattleship.FE/src/pages/SinglePlayerPage.tsx
+++ b/PandaBattleship.FE/src/pages/SinglePlayerPage.tsx
@@ -1,12 +1,12 @@
-import GameOriginal from './components/GameOriginal';
-import { PageHeader } from './components/PageHeader';
+import SinglePlayerGame from '../components/SinglePlayerGame';
+import { PageHeader } from '../components/PageHeader';
 
-export default function AppOriginal() {
+export default function SinglePlayerPage() {
     return (
         <div className="max-w-5xl mx-auto px-1 pb-1 pt-4 text-center min-h-screen flex flex-col items-center">
             <PageHeader />
             <div className="select-none">
-                <GameOriginal />
+                <SinglePlayerGame />
             </div>
         </div>
     )

--- a/PandaBattleship.FE/tests/shipLayouts.test.ts
+++ b/PandaBattleship.FE/tests/shipLayouts.test.ts
@@ -4,7 +4,7 @@ import { processAiShot } from "../src/utils/aiPlayer";
 import { createEmptyGrid } from "../src/utils/gameHelpers";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import GridOriginal from "../src/components/GridOriginal";
+import SinglePlayerBoard from "../src/components/SinglePlayerBoard";
 import type { Ship } from "../src/types/SinglePlayerGame";
 
 describe('shipLayouts', () => {
@@ -85,7 +85,7 @@ describe('shipLayouts', () => {
     const grid = createEmptyGrid();
     grid[1][1] = "hit";
 
-    const markup = renderToStaticMarkup(createElement(GridOriginal, {
+    const markup = renderToStaticMarkup(createElement(SinglePlayerBoard, {
       grid,
       isPlayerGrid: true,
       disabled: true,


### PR DESCRIPTION
## What

Reorganises the FE source so route-level components live in a dedicated `src/pages/` folder, separate from reusable pieces in `src/components/`, and removes the leftover `*Original` naming.

### Moves (`src/components` → `src/pages`)
- `HomePage`, `HelpPage`, `PvpLobbyPage`, `AllShipLayoutsPage`
- `AppOriginal.tsx` (from `src/`) → `SinglePlayerPage` (component renamed from `AppOriginal`/`AiPage`)
- `GamePage.tsx` → `PvpGamePage` (component renamed from `GameBoard`)

### Renames (`*Original` dropped, stay in `src/components`)
- `GameOriginal` → `SinglePlayerGame`
- `GridOriginal` → `SinglePlayerBoard`

### Result
Route components now uniformly use the `*Page` suffix, and the two game modes name symmetrically:

| Route | Page | Game component | Board |
|---|---|---|---|
| `/ai` | `SinglePlayerPage` | `SinglePlayerGame` | `SinglePlayerBoard` |
| `/pvp/:gameId` | `PvpGamePage` | *(inline)* | `Board` |

## Why

Pages and reusable components were mixed together in one folder, and several files still carried an `Original` suffix that no longer meant anything. This makes the structure follow common React conventions and reads consistently.

## Notes for reviewer
- All changes are moves/renames plus updated import paths — no behavioural changes.
- Updated imports in `main.tsx`, the moved files, and `tests/shipLayouts.test.ts`.
- Fixed stale `<Script Include>` paths in `PandaBattleship.FE.esproj`.
- `tsc --noEmit` is clean and the full vitest suite (19 tests) passes.
- `GameOriginal`/`GridOriginal` were the last `*Original` files; `git mv` was used throughout so history is preserved.
