### PR TITLE
Bump test packages in API integration tests

### DIFF
--- a/PandaBattleship.API.IntegrationTests/PandaBattleship.API.IntegrationTests.csproj
+++ b/PandaBattleship.API.IntegrationTests/PandaBattleship.API.IntegrationTests.csproj
@@ -12,8 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Microsoft.AspNetCore.Mvc.Testing 10.0.2 -> 10.0.10 
Microsoft.NET.Test.Sdk 18.0.1 -> 18.8.1

P.S. This was mostly about testing which account is used and how to control that.